### PR TITLE
Add firing script

### DIFF
--- a/index.js
+++ b/index.js
@@ -81,25 +81,14 @@ function generateEpilog(chunkId, imports, exports) {
             window.define(${jsonName}, ${jsonDefineStubs}, function() { return __webpack_exports__[${jsonId}]; });`;
     }
 
+    if (imports.length !== 0) {
+        // Immediately require script
+        epilog += `
+            window.require(['__webpack_export_${chunkId}'], function() {});`;
+    }
+
     epilog += `
         }());`;
-
-    /**
-     * Magento 2's RequireJS implementation appears
-     * to only fire scripts when it needs to.
-     *
-     * Since this is a custom script, it won't
-     * ever - by default - fire. So this is us forcing
-     * the script in question to fire immediately.
-     *
-     * TODO: look into the exact process Magento 2
-     * employs in doing this. There might be a smarter
-     * way to handle execution.
-     */
-    if (imports.length !== 0) {
-        epilog += `
-            window.require(['__webpack_export_0'], function() {});`;
-    }
 
     return epilog;
 }

--- a/index.js
+++ b/index.js
@@ -84,6 +84,23 @@ function generateEpilog(chunkId, imports, exports) {
     epilog += `
         }());`;
 
+    /**
+     * Magento 2's RequireJS implementation appears
+     * to only fire scripts when it needs to.
+     *
+     * Since this is a custom script, it won't
+     * ever - by default - fire. So this is us forcing
+     * the script in question to fire immediately.
+     *
+     * TODO: look into the exact process Magento 2
+     * employs in doing this. There might be a smarter
+     * way to handle execution.
+     */
+    if (imports.length !== 0) {
+        epilog += `
+            window.require(['__webpack_export_0'], function() {});`;
+    }
+
     return epilog;
 }
 


### PR DESCRIPTION
As we're seeing over in the Blank Theme's implementation of Webpack, Magento 2's RequireJS implementation can cause our Webpack bundles to not fire until they're directly requested.

E.g. a Webpack bundled script of:

```js
import $ from 'jquery';

console.log('hello world');
```

Won't ever fire unless one manually calls the bundle.

This PR adds a line to our export plugin's `epilog` for any bundles with imports present to immediately call the bundle.