### PR TITLE
Check if module is jquery and prefix mixins

### DIFF
--- a/index.js
+++ b/index.js
@@ -10,7 +10,9 @@ function gatherRequireJsImports(modules) {
     for (var module of modules) {
         // If the requirejs-loader was used, then we need to wrap and import this module.
         // TODO: Clean up this check.
-        if (module.request && String(module.request).indexOf('requirejs-loader') !== -1) {
+        if (module.request && String(module.request).indexOf('jquery.js') !== -1) {
+            needsImport.push('mixins!' + module.rawRequest);
+        } else if (module.request && String(module.request).indexOf('requirejs-loader') !== -1) {
             needsImport.push(module.rawRequest);
         }
     }


### PR DESCRIPTION
Magento added a jQuery patch in all recent releases 2.1.16, 2.2.7, 2.3.0 which broke jQuery for us. This references the mixins versions: magento/magento2@d588b5b