### PR TITLE
Made RequireJS Export Compatible to Webpack 5

### DIFF
--- a/index.js
+++ b/index.js
@@ -101,6 +101,43 @@ RequireJsExportPlugin.prototype.apply = function (compiler) {
 
         compiler.hooks.compilation.tap('RequireJsExportPlugin', (compilation) => {
             const Compilation = compiler.webpack.Compilation;
+            const JavascriptModulesPlugin =
+                compiler.webpack.javascript.JavascriptModulesPlugin;
+
+            const jsHooks =
+                JavascriptModulesPlugin.getCompilationHooks(compilation);
+
+            jsHooks.renderModuleContent.tap(
+                'RequireJsExportPlugin',
+                (source, module) => {
+
+                    if (!shouldExport(module)) {
+                        return source;
+                    }
+
+                    return new ConcatSource(
+                        source,
+                        `
+
+                            window.__requirejs_exports__ =
+                                window.__requirejs_exports__ || {};
+
+                            if (typeof __webpack_exports__ !== 'undefined') {
+                                window.__requirejs_exports__[${JSON.stringify(module.id)}] =
+                                    (__webpack_exports__ &&
+                                    __webpack_exports__.__esModule &&
+                                    Object.prototype.hasOwnProperty.call(
+                                        __webpack_exports__,
+                                        'default'
+                                    ))
+                                        ? __webpack_exports__.default
+                                        : __webpack_exports__;
+                            }
+
+                        `
+                    );
+                }
+            );
 
             compilation.hooks.processAssets.tap(
                 {
@@ -118,12 +155,6 @@ RequireJsExportPlugin.prototype.apply = function (compiler) {
 
                         if (needsImport.length === 0 && needsExport.length === 0) continue;
 
-                        const captureCode = needsExport
-                            .map(({ id }) =>
-                                ` try { __requirejs_exports__[${JSON.stringify(id)}] = __webpack_require__(${JSON.stringify(id)}); } catch(e) { /* Intentionally ignore modules that cannot be required in this chunk context. */ }`
-                            )
-                            .join('\n');
-
                         const prolog = generateProlog(chunk.id, needsImport, needsExport);
                         const epilog = generateEpilog(chunk.id, needsImport, needsExport);
 
@@ -132,7 +163,7 @@ RequireJsExportPlugin.prototype.apply = function (compiler) {
 
                             compilation.updateAsset(
                                 filename,
-                                (old) => new ConcatSource(prolog, '\n', old, '\n', captureCode, '\n', epilog)
+                                (old) => new ConcatSource(prolog, '\n', old, '\n', epilog)
                             );
                         }
                     }

--- a/index.js
+++ b/index.js
@@ -118,7 +118,6 @@ RequireJsExportPlugin.prototype.apply = function (compiler) {
                     return new ConcatSource(
                         source,
                         `
-
                             window.__requirejs_exports__ =
                                 window.__requirejs_exports__ || {};
 
@@ -133,7 +132,6 @@ RequireJsExportPlugin.prototype.apply = function (compiler) {
                                         ? __webpack_exports__.default
                                         : __webpack_exports__;
                             }
-
                         `
                     );
                 }
@@ -155,7 +153,7 @@ RequireJsExportPlugin.prototype.apply = function (compiler) {
 
                         if (needsImport.length === 0 && needsExport.length === 0) continue;
 
-                        const prolog = generateProlog(chunk.id, needsImport, needsExport);
+                        const prolog = generateProlog(chunk.id, needsImport);
                         const epilog = generateEpilog(chunk.id, needsImport, needsExport);
 
                         for (const filename of chunk.files) {
@@ -190,7 +188,7 @@ RequireJsExportPlugin.prototype.apply = function (compiler) {
 
                 if (needsImport.length === 0 && needsExport.length === 0) return;
 
-                const prolog = generateProlog(chunk.id, needsImport, needsExport);
+                const prolog = generateProlog(chunk.id, needsImport);
                 const epilog = generateEpilog(chunk.id, needsImport, needsExport);
 
                 compilation.assets[filename] = new ConcatSource(prolog, "\n", compilation.assets[filename], "\n", epilog);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sdinteractive/requirejs-export-plugin",
-  "version": "4.0.0",
+  "version": "4.0.1",
   "description": "webpack plugin to export modules to requirejs. Supports webpack 4 and webpack 5.",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
**PR Summary:**
We investigated and fixed the webpack 5 migration of the RequireJsExportPlugin. The original webpack 4 implementation exported modules by injecting code directly into each module, but during the webpack 5 upgrade this had been replaced with runtime capture using __webpack_require__, which caused cross-chunk dependency issues, missing jQuery/core-js modules, and failed exports. We restored the original behavior by using webpack 5's JavascriptModulesPlugin.renderModuleContent hook to inject export registration into each module, with safeguards for non-ES modules. After the change, RequireJS aliases and module exports work correctly again, and the site is functioning without console errors.